### PR TITLE
Add dry-dock environment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,21 @@
+#####################
+ISEMS-ESP32 changelog
+#####################
+
+
+2020-01-09 0.0.0
+================
+- Add the full set of LUA files to run the new hardware board.
+- Fix temperature sensor detection and battery charge state estimatation bugs.
+- Cleanup debugging statements.
+
+
+2019-12-03 0.0.0
+================
+- Add preliminary version of ISEMS-ESP32 for external module.
+
+
+2019-10-07 0.0.0
+================
+- Initial commit.
+- Add README.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ ISEMS-ESP32 changelog
 #####################
 
 
+Development
+===========
+- Add dry-dock environment.
+
+
 2020-01-09 0.0.0
 ================
 - Add the full set of LUA files to run the new hardware board.

--- a/LUA/ff-esp32-openmppt/test/README.rst
+++ b/LUA/ff-esp32-openmppt/test/README.rst
@@ -1,0 +1,14 @@
+####################
+ISEMS-ESP32 dry-dock
+####################
+
+About
+=====
+This environment makes it possible to run parts of the
+ISEMS-ESP32 Node MCU Lua code on a vanilla PC.
+
+Synopsis
+========
+::
+
+	lua test/run_basic.lua

--- a/LUA/ff-esp32-openmppt/test/nodemcu_mock.lua
+++ b/LUA/ff-esp32-openmppt/test/nodemcu_mock.lua
@@ -1,0 +1,40 @@
+--[[
+Mock the API of a NodeMCU device.
+]]
+
+time = {
+    get = function()
+        return os.time()
+    end,
+    getlocal = function()
+        date = os.date("*t")
+        date["mon"] = date["month"]
+        date["dst"] = "1"
+        return date
+    end,
+}
+
+node = {
+    dsleep = function() end,
+}
+
+file = {
+    list = function() end,
+    exists = function() end,
+}
+
+gpio = {
+    config = function() end,
+    wakeup = function() end,
+    write = function() end,
+}
+
+dac = {
+    enable = function() end,
+}
+
+adc = {
+    setup = function() end,
+    setwidth = function() end,
+    read = function() return 42.42 end,
+}

--- a/LUA/ff-esp32-openmppt/test/run_basic.lua
+++ b/LUA/ff-esp32-openmppt/test/run_basic.lua
@@ -1,0 +1,14 @@
+--[[
+Run a single duty cycle to completion.
+]]
+
+-- Bootstrap
+dofile "test/nodemcu_mock.lua"
+dofile "config.lua"
+
+-- No periodic execution.
+-- dofile "is.lua"
+
+-- Run cycle.
+Vref = 1100 --mV
+dofile "mp2.lua"


### PR DESCRIPTION
Dear @elektra42,

first things first: Thanks for conceiving this fine piece of hard- and software.

In order to work further on the codebase without a device at hand, this contribution adds a humble dry-dock environment, i.e. mocks the NodeMCU API to make the firmware run a single duty cycle to completion, even on a regular PC.

In order to invoke this, just type
```
lua test/run_basic.lua
```

With kind regards,
Andreas.
