### PR TITLE
Mixed up endpoint suffixes of MQTT vs. HTTP. This fixes that glitch.

### DIFF
--- a/LUA/ff-esp32-openmppt/telemetry.lua
+++ b/LUA/ff-esp32-openmppt/telemetry.lua
@@ -4,11 +4,11 @@ Telemetry implementation for MQTT and HTTP.
 
 telemetry_channel_node = telemetry_channel .. nodeid
 
-mqtt_topic = telemetry_channel_node
+mqtt_topic = telemetry_channel_node .. "/data.json"
 
 print("mqtt_topic: ", mqtt_topic)
 
-http_endpoint = telemetry_http_endpoint .. telemetry_channel_node .. "/data.json"
+http_endpoint = telemetry_http_endpoint .. telemetry_channel_node .. "/data"
 
 print("Http telemetry url:", http_endpoint)
 


### PR DESCRIPTION
`mqtt_topic` and `http_endpoint` have been populated with the wrong endpoint suffixes. Correct is `/data.json` (MQTT) vs. `/data` (HTTP). This should make telemetry finally work.