### PR TITLE
Refactor and improve HTTP server

### DIFF
--- a/LUA/ff-esp32-openmppt/is.lua
+++ b/LUA/ff-esp32-openmppt/is.lua
@@ -132,20 +132,24 @@ srv:listen(80, function(conn)
                     print("HELP")
                     help_page = [[
                         <html>
-                        Commands on this device can be executed remotely by sending HTTP GET requests.
+                        Commands on this device can be executed remotely by sending HTTP POST requests + secret-key.
                         <br><br>
 
-                        For example, if you open <b>http://IP-or-URL-of-FF-ESP32-device/ftp+secret123</b> in a browser,
+                        Assuming your secret-key is "secret123", if you invoke
+                        <pre>curl http://IP-or-URL-of-FF-ESP32-device --request POST --data-raw 'ftp+secret123'</pre>,
                         the system will start a FTP server and stop the main program loop to free up CPU and RAM resources.
                         <br><br>
-                        Now you can upload a customized version of <b>config.lua</b> via FTP
-                        with the default FTP user-password combination <b>admin / pass123</b>.
-                        <br><br>
-                        All passwords are stored in <b>config.lua</b> and should be changed before deploying the system, of course.
-                        Reboot the device to apply the new config.
+
+                        Now, you can upload a customized version of <b>config.lua</b> via FTP
+                        with the default FTP user-password combination <b>admin / pass123</b> like
+                        <pre>lftp -u admin,pass123 IP-or-URL-of-FF-ESP32-device -c 'put config.lua'</pre>
                         <br><br>
 
-                        <h3>Commands:</h3>
+                        All passwords are stored in <b>config.lua</b> and should be changed before deploying the system, of course.
+                        Just reboot the device to apply the new configuration.
+                        <br><br>
+
+                        <h3>Commands</h3>
                         <b>/ftp+key</b> (starts ftp server and pauses the main MPPT program)<br>
                         <b>/reboot+key</b><br><b>/telnet+key</b> (starts an open (!) telnet LUA command line interface at port 2323)<br>
                         <b>/shell+key</b> (starts an open (!) Unix-like minimal commandline interface at telnet port 2333)<br>
@@ -153,12 +157,11 @@ srv:listen(80, function(conn)
                         <b>/loadoff+key</b> Turn load off.<br>
                         <b>/loadon+key</b> Turn load on.<br>
 
-                        <h3>
-                            Use your passwords only over a encrypted WiFi and if you trust the network.
-                            FTP and HTTP keys can be sniffed easily, as they are sent unencrypted.
-                            Links are case sensitive. Remember that this is a tiny device with very limited ressources.
-                            If all features are enabled, the device might occasionally run out of memory, crash and reboot.
-                        </h3>
+                        <h3>Caveats</h3>
+                        Use your passwords only over a encrypted WiFi and if you trust the network.
+                        FTP and HTTP keys can be sniffed easily, as they are sent unencrypted.
+                        Links are case sensitive. Remember that this is a tiny device with very limited ressources.
+                        If all features are enabled, the device might occasionally run out of memory, crash and reboot.
 
                         </html>
                         ]]

--- a/LUA/ff-esp32-openmppt/is.lua
+++ b/LUA/ff-esp32-openmppt/is.lua
@@ -92,6 +92,9 @@ srv:listen(80, function(conn)
                     sck:send(http_preamble .. response)
                 end
 
+                -- HTTP method.
+                method_post = string.match(payload, "POST")
+
                 -- Authentication key.
                 key  = string.match(payload, webkeyhash)
 
@@ -172,6 +175,12 @@ srv:listen(80, function(conn)
 
 
                 -- Invoke device commands.
+
+                -- Protect against invalid HTTP method.
+                if method_post == nil then
+                    send_response("Will not execute the command. Reason: Invoking commands needs HTTP POST.")
+                    return
+                end
 
                 -- Protect against unauthorized access.
                 if key == nil then

--- a/LUA/ff-esp32-openmppt/mp2.lua
+++ b/LUA/ff-esp32-openmppt/mp2.lua
@@ -544,7 +544,7 @@ end
 node_uptime = math.floor((node.uptime() / 1000000))
 
 -- HTML output
-        pagestring = "HTTP/1.0 200 OK\r\nContent-Type: text/html\r\n\r\n<h1>Independent Solar Energy Mesh</h1><br><h2>Status of " .. nodeid
+        pagestring = "<h1>Independent Solar Energy Mesh</h1><br><h2>Status of " .. nodeid
         pagestring = pagestring  .. " (local node)</h2><br><br>Summary: " .. charge_status  .. ". " .. system_status
         pagestring = pagestring  .. "<br>Charge state: " 
         pagestring = pagestring .. charge_state_int


### PR DESCRIPTION
Dear @elektra42,

coming from the discussion within #5, I tried my best to improve the code base beforehand and then add the gist of 4c972d5 to this pull request. This will prevent accidental invocations of actions on the device even without any one-time-passwords or further cryptography involved.

In the world of HTTP, using POST requests for things like that is somehow a matter of good manners.

I've also added corresponding command line examples like
```
# Enable FTP server.
curl http://ff-isems-node --request POST --data-raw 'ftp+secret123'

# Upload configuration file.
lftp -u admin,pass123 ff-isems-node -c 'put config.lua'
```

Thanks already for taking the time to look into this.

Cheers,
Andreas.

P.S.: The reformatting through 7450c8d is also important for following up on this work by #6. For making this happen, we will detach the action dispatcher from the HTTP server implementation in order to use it from both the HTTP server and a MQTT subscriber.

P.P.S.: Invoking commands is even more convenient using [HTTPie](https://httpie.org/).
```
echo 'ftp+secret123' | http POST http://ff-isems-node --form
```
